### PR TITLE
expose full jupyter url

### DIFF
--- a/bin/jpynb
+++ b/bin/jpynb
@@ -13,4 +13,4 @@ Open a separate terminal on your local machine, and use the following to create 
 ssh -N -f -L ${PORT}:${node}:${PORT} ${user}@bunya.rcc.uq.edu.au
 "
 
-jupyter notebook --no-browser --port=${PORT} --ip=${node} --ServerApp.token=abcd --NotebookApp.custom_display_url=http://localhost:${PORT}/
+jupyter notebook --no-browser --port=${PORT} --ip=${node} --NotebookApp.custom_display_url=http://localhost:${PORT}/

--- a/bin/jpynbw
+++ b/bin/jpynbw
@@ -13,4 +13,4 @@ Open a separate terminal on your local machine, and use the following to create 
 ssh -N -f -L ${PORT}:${node}:${PORT} ${user}@wiener.hpc.dc.uq.edu.au
 "
 
-jupyter notebook --no-browser --port=${PORT} --ip=${node} --ServerApp.token=abcd --NotebookApp.custom_display_url=http://localhost:${PORT}/
+jupyter notebook --no-browser --port=${PORT} --ip=${node} --NotebookApp.custom_display_url=http://localhost:${PORT}/


### PR DESCRIPTION
newer jupyter versions(?) would not expose the full url that contains the token.

When setting up on VSCode this poses a problem as I and others as well do not have the url to setup the kernel in VSCode